### PR TITLE
Add codes.js file.

### DIFF
--- a/codes.js
+++ b/codes.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./codes.json')


### PR DESCRIPTION
There are two benefits to this simple PR.

1) It is now easier to import just the status codes `require("statuses/codes")`.
2) TypeScript does not allow you to import json.

For me personally I'm trying to `import * as CODES from "statuses/codes"` in TypeScript, however it's a bit of a pain since you cannot import json by default.

You could alternatively remove `codes.json` and just make a `codes.js` file, however I opted against this for compatibility with those requiring the son directly.