### PR TITLE
Expose status code map.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ status('Forbidden') // => 403
 status(306) // throws, as it's not supported by node.js
 ```
 
+### status.STATUS_CODES
+
+Returns an `object` which maps status codes to status messages.
+
 ### status.codes
 
 Returns an array of all the status codes as `Integer`s.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ var codes = require('./codes.json')
 
 module.exports = status
 
+// raw status codes.
+status.STATUS_CODES = codes
+
 // array of status codes
 status.codes = populateStatusesMap(status, codes)
 

--- a/test/test.js
+++ b/test/test.js
@@ -75,6 +75,18 @@ describe('status', function () {
     })
   })
 
+  describe('.STATUS_CODES', function () {
+    it('should contain the expected ok status', function () {
+      assert.equal(status.STATUS_CODES[200], 'OK')
+    })
+
+    it('should include status code map from Node.js', function () {
+      Object.keys(http.STATUS_CODES).forEach(function forEachCode (code) {
+        assert.ok(status.STATUS_CODES[code], 'contains ' + code)
+      })
+    })
+  })
+
   describe('.codes', function () {
     it('should include codes from Node.js', function () {
       Object.keys(http.STATUS_CODES).forEach(function forEachCode (code) {


### PR DESCRIPTION
Exposes the raw status code map from `codes.json`.

Related: https://github.com/jshttp/statuses/pull/13