### PR TITLE
Add support for status code 530

### DIFF
--- a/codes.json
+++ b/codes.json
@@ -61,5 +61,6 @@
   "508": "Loop Detected",
   "509": "Bandwidth Limit Exceeded",
   "510": "Not Extended",
-  "511": "Network Authentication Required"
+  "511": "Network Authentication Required",
+  "530": "Site is frozen"
 }

--- a/lib/unofficial.json
+++ b/lib/unofficial.json
@@ -1,0 +1,3 @@
+{
+  "530": "Site is frozen"
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,7 +11,8 @@ var codes = require('../src/iana.json')
   'draft',
   'apache',
   'nginx',
-  'node'
+  'node',
+  'unofficial'
 ].forEach(function (src) {
   var json = require('../lib/' + src + '.json')
   Object.keys(json).forEach(function (key) {


### PR DESCRIPTION
Cloudflare returns a 530 if there is a DNS error on the origin. Not really sure how to classify this other than "unofficial". It is a common FTP code, but on an FTP context it means "Not logged in". I'm open to suggestions.

Source: https://support.cloudflare.com/hc/en-us/articles/234979888-Error-1016-Origin-DNS-error