### PR TITLE
Throw on code 306

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
   * Drop support for Node.js 0.6
   * Fix messaging casing of `418 I'm a Teapot`
+  * Remove code 306
   * Remove `status[code]` exports; use `status.message[code]`
   * Remove `status[msg]` exports; use `status.code[msg]`
   * Rename `425 Unordered Collection` to standard `425 Too Early`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ status(403) // => 'Forbibben'
 status('403') // => 'Forbibben'
 status('forbidden') // => 403
 status('Forbidden') // => 403
-status(306) // throws, as it's not supported by node.js
+status(306) // throws, as it's no longer supported by the HTTP spec
 ```
 
 ### status.codes

--- a/codes.json
+++ b/codes.json
@@ -19,7 +19,6 @@
   "303": "See Other",
   "304": "Not Modified",
   "305": "Use Proxy",
-  "306": "(Unused)",
   "307": "Temporary Redirect",
   "308": "Permanent Redirect",
   "400": "Bad Request",

--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -20,9 +20,17 @@ https.get(URL, { headers: HEADERS }, function onResponse (res) {
     rows.forEach(function (row) {
       var obj = row.reduce(reduceRows, {})
 
-      if (obj.description !== 'Unassigned') {
-        codes[obj.value] = obj.description
+      // skip unassigned codes
+      if (obj.description === 'Unassigned') {
+        return
       }
+
+      // skip retired 306 code
+      if (obj.value === '306') {
+        return
+      }
+
+      codes[obj.value] = obj.description
     })
 
     write(path.join(__dirname, '../src/iana.json'), codes)

--- a/src/iana.json
+++ b/src/iana.json
@@ -19,7 +19,6 @@
   "303": "See Other",
   "304": "Not Modified",
   "305": "Use Proxy",
-  "306": "(Unused)",
   "307": "Temporary Redirect",
   "308": "Permanent Redirect",
   "400": "Bad Request",

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,10 @@ describe('status', function () {
       assert.throws(status.bind(null, 299), /invalid status code/)
       assert.throws(status.bind(null, 310), /invalid status code/)
     })
+
+    it('should throw for discontinued status code', function () {
+      assert.throws(status.bind(null, 306), /invalid status code/)
+    })
   })
 
   describe('when given a string', function () {


### PR DESCRIPTION
This is just a suggestion based on issue #18.

I have removed code 306 after `codes.json` is required to make `status(306)` throw as is indicated in the docs. 

I assume this would be a breaking change. 

The main question is:

### Should 306 throw an error? 

Assuming it should, when fetching the IANA codes we could remove it from the response before writing it to `iana.json`. Or it could be manually edited like I see has been done for some other codes like in c46c4d4d8b85814c0e65f99af8ce3137bca6b0ea.

If 306 should not throw, the docs can just be updated.