### PR TITLE
Throw when passed strings on Object.prototype

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix returning values from `Object.prototype`
+
 2.0.0 / 2020-04-19
 ==================
 

--- a/index.js
+++ b/index.js
@@ -86,6 +86,34 @@ function createStatusCodeList (codes) {
 }
 
 /**
+ * Get the status code for given message.
+ * @private
+ */
+
+function getStatusCode (message) {
+  var msg = message.toLowerCase()
+
+  if (!Object.prototype.hasOwnProperty.call(status.code, msg)) {
+    throw new Error('invalid status message: "' + message + '"')
+  }
+
+  return status.code[msg]
+}
+
+/**
+ * Get the status message for given code.
+ * @private
+ */
+
+function getStatusMessage (code) {
+  if (!Object.prototype.hasOwnProperty.call(status.message, code)) {
+    throw new Error('invalid status code: ' + code)
+  }
+
+  return status.message[code]
+}
+
+/**
  * Get the status code.
  *
  * Given a number, this will throw if it is not a known status
@@ -101,8 +129,7 @@ function createStatusCodeList (codes) {
 
 function status (code) {
   if (typeof code === 'number') {
-    if (!status.message[code]) throw new Error('invalid status code: ' + code)
-    return status.message[code]
+    return getStatusMessage(code)
   }
 
   if (typeof code !== 'string') {
@@ -112,11 +139,8 @@ function status (code) {
   // '403'
   var n = parseInt(code, 10)
   if (!isNaN(n)) {
-    if (!status.message[n]) throw new Error('invalid status code: ' + n)
-    return status.message[n]
+    return getStatusMessage(n)
   }
 
-  n = status.code[code.toLowerCase()]
-  if (!n) throw new Error('invalid status message: "' + code + '"')
-  return n
+  return getStatusCode(code)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,8 @@ describe('status', function () {
 
     it('should throw for unknown status message', function () {
       assert.throws(status.bind(null, 'too many bugs'), /invalid status message/)
+      assert.throws(status.bind(null, 'constructor'), /invalid status message/)
+      assert.throws(status.bind(null, '__proto__'), /invalid status message/)
     })
 
     it('should throw for unknown status code', function () {


### PR DESCRIPTION
Because `'constructor' in Object.prototype`, `status('constructor')` would return `Object.prototype.constructor`. This was true for any all-lowercase key, which is currently `__proto__` and `constructor`.

Here's the meat of the change:

```diff
-  var map = {}
+  var map = Object.create(null)
```