### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/fetch-iana.js
+++ b/scripts/fetch-iana.js
@@ -48,7 +48,7 @@ function generateRowMapper (headers) {
 }
 
 function normalizeHeader (val) {
-  return val.substr(0, 1).toLowerCase() + val.substr(1).replace(/ (.)/, function (s, c) {
+  return val.slice(0, 1).toLowerCase() + val.slice(1).replace(/ (.)/, function (s, c) {
     return c.toUpperCase()
   })
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.