### PR TITLE
chore: pin dependencies and specify permissions in the pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,15 @@ on:
 - pull_request
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      checks: write  # for coverallsapp/github-action to create new checks
     strategy:
       matrix:
         name:
@@ -101,7 +107,7 @@ jobs:
           node-version: "16.2"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
@@ -164,7 +170,7 @@ jobs:
       run: npm run lint
 
     - name: Collect code coverage
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 #v2.2.3
       if: steps.list_env.outputs.nyc != ''
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -174,9 +180,12 @@ jobs:
   coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      checks: write  # for coverallsapp/github-action to create new checks
     steps:
     - name: Upload code coverage
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 #v2.2.3
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true


### PR DESCRIPTION
## Main Changes

This change includes the pinning for the GitHub Actions dependencies and the permissions definition for the pipeline.

## Impact in the OSSF Scorecard

<img width="1307" alt="Captura de pantalla 2024-03-14 a las 21 18 47" src="https://github.com/jshttp/statuses/assets/25435858/18349a74-bc8f-45aa-9f41-d69073613a90">
<img width="1320" alt="Captura de pantalla 2024-03-14 a las 21 18 59" src="https://github.com/jshttp/statuses/assets/25435858/4a2c4c9a-b636-41c6-9dc2-42164fc93856">

## Context

### Changes related

- [OSSF Scorecard Documentation | Tokens permissions](https://github.com/ossf/scorecard/blob/a25f108f4b0c1c5a6e6c4b99f4c4e0b0710555a9/docs/checks.md#token-permissions)
- [OSSF Scorecard Documentation | Pinned dependencies](https://github.com/ossf/scorecard/blob/a25f108f4b0c1c5a6e6c4b99f4c4e0b0710555a9/docs/checks.md#pinned-dependencies)

### Team discussion related

- Ref: https://github.com/expressjs/security-wg/issues/2
- Report: https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/jshttp/statuses/commit/454ceb6e0bfea4f889be244de2538df8afb4dc2a