### PR TITLE
chore: add dependency review tool

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@9129d7d40b8c12c1ed0f60400d00c92d437adcce # v4.1.3


### PR DESCRIPTION
## Main Changes

This GitHub action will add an additional check when a PR is created in the project and will review any change in the dependencies.

> This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
[Source repository](https://github.com/actions/dependency-review-action)

Overall, this will prevent us from introducing vulnerable dependencies versions without the need to manually check that.

## Impact in the OSSF Scorecard

<img width="1313" alt="Captura de pantalla 2024-03-14 a las 21 38 51" src="https://github.com/jshttp/statuses/assets/25435858/38101a06-aba6-4695-b349-c1ad00a50b2d">

Note that our current score is 10/10, so this is a preventive measurement.

## Context

- Ref: https://github.com/expressjs/security-wg/issues/2
- Report: https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/jshttp/statuses/commit/454ceb6e0bfea4f889be244de2538df8afb4dc2a