### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       time: "23:00"
       timezone: Europe/London
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      time: "23:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Main Changes

`dependabot` will check for available updates for the dependencies that we use in the project. In the current setup, it will generate PRs once per week if the are new versions for our dependencies (`npm` and Github Actions).

We can remove npm and limit it to Github Actions, as well we can modify the frequency.

`dependabot` is capable of following the pin version schema introduced in https://github.com/jshttp/statuses/pull/25, so it will be able to upgrade and pin the Github actions accordingly.

The configuration is very flexible, see the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

## Context

- Ref: https://github.com/expressjs/security-wg/issues/2
- Report: https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/jshttp/statuses/commit/454ceb6e0bfea4f889be244de2538df8afb4dc2a